### PR TITLE
langchain 0.3.12

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 channels:
   - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr6/e6e69e0
   - https://staging.continuum.io/prefect/fs/langchain-text-splitters-feedstock/pr4/d2bb8ca
+  - https://staging.continuum.io/prefect/fs/langchain-feedstock/pr6/69eb35c
+  - https://staging.continuum.io/prefect/fs/httpx-sse-feedstock/pr1/1e6aaad

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
-upload_channels:
-  - sfe1ed40
 channels:
-  - sfe1ed40
+  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr6/e6e69e0
+  - https://staging.continuum.io/prefect/fs/langchain-text-splitters-feedstock/pr4/d2bb8ca

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr6/e6e69e0
   - https://staging.continuum.io/prefect/fs/langchain-text-splitters-feedstock/pr4/d2bb8ca
-  - https://staging.continuum.io/prefect/fs/langchain-feedstock/pr6/69eb35c
   - https://staging.continuum.io/prefect/fs/httpx-sse-feedstock/pr1/1e6aaad

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/langchain-core-feedstock/pr6/e6e69e0
-  - https://staging.continuum.io/prefect/fs/langchain-text-splitters-feedstock/pr4/d2bb8ca
-  - https://staging.continuum.io/prefect/fs/httpx-sse-feedstock/pr1/1e6aaad

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,19 @@
 {% set name = "langchain" %}
-{% set version = "0.1.15" %}
+{% set version = "0.3.12" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/langchain-ai/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: e1bb700252a1d574845082c86f89f039e7dee7a4894f014abf10991b87a66ae3
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/langchain-{{ version }}.tar.gz
+  sha256: 0d8247afbf37beb263b4adc29f7aa8a5ae83c43a6941894e2f9ba39d5c869e3b
 
 build:
   number: 0
   skip: True # [py<38]
-  script: 
-    - {{ PYTHON }} -m pip install ./libs/langchain -vv --no-deps --no-build-isolation
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - langchain-server = langchain.server:main
 
@@ -23,110 +23,41 @@ requirements:
     - python
     - poetry-core >=1.0.0
   run:
-    - aiohttp >=3.8.3,<4.0.0
-    - async-timeout >=4.0.0,<5.0.0  # [py<311]
-    - dataclasses-json >=0.5.7,<0.7.0
-    - jsonpatch >=1.33,<2.0
-    - langchain-community >=0.0.32,<0.1
-    - langchain-core >=0.1.41,<0.2.0
-    - langchain-text-splitters >=0.0.1,<0.1
-    - langsmith >=0.1.17,<0.2.0
-    - numpy >=1.0.0,<2.0.0
-    - pydantic >=1.0.0,<3.0.0
     - python
-    - pyyaml >=5.3
-    - requests >=2.0.0,<3.0.0
+    - langchain-core <0.4.0,>=0.3.24
+    - langchain-text-splitters <0.4.0,>=0.3.3
+    - langsmith >=0.1.17,<0.2.0
+    - pydantic >=1,<3
     - sqlalchemy >=1.4,<3
+    - requests >=2.0.0,<3.0.0
+    - pyyaml >=5.3
+    - numpy >=1.0.0,<2.0.0
+    - aiohttp >=3.8.3,<4.0.0
     - tenacity >=8.1.0,<9.0.0
+    - async-timeout >=4.0.0,<5.0.0
   run_constrained:
-    - aiosqlite >=0.19.0,<0.20.0
-    - aleph-alpha-client >=2.15.0,<3.0.0
-    - anthropic >=0.3.11,<0.4.0
-    - arxiv >=1.4.0,<2.0.0
-    - assemblyai >=0.17.0,<0.18.0
-    - atlassian-python-api >=3.36.0,<4.0.0
-    - awadb >=0.3.9,<0.4.0
-    - azure-ai-formrecognizer >=3.2.1,<4.0.0
-    - azure-ai-textanalytics >=5.3.0,<6.0.0
-    - azure-cognitiveservices-speech >=1.28.0,<2.0.0
-    - azure-core >=1.26.4,<2.0.0
-    - azure-cosmos >=4.4.0b1,<5.0.0
-    - azure-identity >=1.12.0,<2.0.0
-    - azure-search-documents 11.4.0b8
-    - beautifulsoup4 >=4.0.0,<5.0.0
-    - bibtexparser >=1.4.0,<2.0.0
-    - cassio >=0.1.0,<0.2.0
-    - chardet >=5.1.0,<6.0.0
-    - clarifai >=9.1.0
-    - clickhouse-connect >=0.5.14,<0.6.0
-    - cohere >=4.0.0,<6.0.0
-    - couchbase >=4.1.9,<5.0.0
-    - dashvector >=1.0.1,<2.0.0
-    - databricks-vectorsearch >=0.21,<0.22
-    - datasets >=2.15.0,<3.0.0
-    - dgml-utils >=0.3.0,<0.4.0
-    - docarray >=0.32.0,<0.33.0
-    - esprima-python >=4.0.1,<5.0.0
-    - faiss-cpu >=1.0.0,<2.0.0
-    - feedparser >=6.0.10,<7.0.0
-    - fireworks-ai >=0.9.0,<0.10.0
-    - geopandas >=0.13.1,<0.14.0
-    - gitpython >=3.1.32,<4.0.0
-    - google-cloud-documentai <=2.20.1,<3.0.0
-    - gql >=3.4.1,<4.0.0
-    - hologres-vector >=0.0.6,<0.0.7
-    - html2text >=2020.1.16,<2021.0.0
-    - huggingface_hub >=0.0.0,<1.0.0
-    - javelin-sdk >=0.1.8,<0.2.0
-    - jinja2 >=3.0.0,<4.0.0
-    - jq >=1.4.1,<2.0.0
-    - jsonschema >1
-    - langchain-openai >=0.0.2,<0.1
-    - lxml >=4.9.3,<6.0.0
-    - markdownify >=0.11.6,<0.12.0
-    - motor >=3.3.1,<4.0.0
-    - msal >=1.25.0,<2.0.0
-    - mwparserfromhell >=0.6.4,<0.7.0
-    - mwxml >=0.3.3,<0.4.0
-    - newspaper3k >=0.2.8,<0.3.0
-    - nlpcloud >=1.0.0,<2.0.0
-    - numexpr >=2.8.6,<3.0.0
-    - openai <2.0.0
-    - openapi-pydantic >=0.3.2,<0.4.0
-    - openlm >=0.0.5,<0.0.6
-    - pandas >=2.0.1,<3.0.0
-    - pdfminer-six >=20221105.0.0,<20221106.0.0
-    - pgvector >=0.1.6,<0.2.0
-    - praw >=7.7.1,<8.0.0
-    - psychicapi >=0.8.0,<0.9.0
-    - py-trello >=0.19.0,<0.20.0
-    - pymupdf >=1.22.3,<2.0.0
-    - pypdf >=3.4.0,<4.0.0
-    - pypdfium2 >=4.10.0,<5.0.0
-    - pyspark >=3.4.0,<4.0.0
-    - pytorch >=1,<3
-    - qdrant-client >=1.3.1,<2.0.0
-    - rank-bm25 >=0.2.2,<0.3.0
-    - rapidfuzz >=3.1.1,<4.0.0
-    - rapidocr-onnxruntime >=1.3.2,<2.0.0  # [py<312]
-    - rdflib =7.0.0
-    - requests-toolbelt >=1.0.0,<2.0.0
-    - rspace_client >=2.5.0,<3.0.0
-    - scikit-learn >=1.2.2,<2.0.0
-    - sentence-transformers >=2.0.0,<3.0.0
-    - sqlite-vss >=0.1.2,<0.2.0
-    - streamlit >=1.18.0,<2.0.0
-    - sympy >=1.12.0,<2.0.0
-    - telethon >=1.28.5,<2.0.0
-    - tenacity >=8.1.0,<9.0.0
-    - tiktoken >=0.3.2,<0.6.0  # [py>=39]
-    - timescale-vector >=0.0.1,<0.0.2
-    - tqdm >=4.48.0
-    - transformers >=4.0.0,<5.0.0
-    - typer >=0.9.0,<0.10.0
-    - upstash-redis >=0.15.0,<0.16.0
-    - xata >=1.0.0,<2.0.0
-    - xmltodict >=0.13.0,<0.14.0
+    # based on https://github.com/langchain-ai/langchain/blob/master/libs/langchain/extended_testing_deps.txt
+    - jsonschema >=4.22.0,<5
+    - numexpr >=2.8.6,<3
+    - rapidfuzz >=3.1.1,<4
+    - aiosqlite >=0.19.0,<0.20
+    # copied from langchain-openai-feedstock
+    - openai >=1.26.0,<2.0.0
+    - tiktoken >=0.7,<1
+    # copied from langchain-anthropic-feedstock
+    - anthropic >=0.28.0,<1
+    - defusedxml <0.8.0,>=0.7.1
+    # copied from langchain-fireworks-feedstock and langchain-together-feedstock
+    - fireworks-ai >=0.13.0
+    - openai >=1.10.0,<2.0.0
+    - requests >=2.0.0,<3.0.0
+    - aiohttp >=3.9.1,<4.0.0
+    # copied from langchain-mistralai-feedstock
+    - tokenizers >=0.15.1,<1
+    - httpx >=0.25.2,<1
+    - httpx-sse >=0.3.1,<1
+    # copied from langchain-groq-feedstock
+    - groq >=0.4.1,<1
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # langsmith not available for s390x
-  skip: True # [py<38 or s390x]
+  skip: True  # [py<38 or s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True # [py<38]
+  # langsmith not available for s390x
+  skip: True # [py<38 or s390x]
   script:
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6020](https://anaconda.atlassian.net/browse/PKG-6020)
- [Upstream repository](https://github.com/langchain-ai/langchain/tree/v0.1.16)
- [Upstream changelog/diff](https://github.com/langchain-ai/langchain/releases)

### Explanation of changes:

- Update version
- Sync dependencies with conda-forge
- Skip s390x (`langsmith` not available)


[PKG-6020]: https://anaconda.atlassian.net/browse/PKG-6020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ